### PR TITLE
Additional MuJoCo path for CMake

### DIFF
--- a/cmake/Findglfw3.cmake
+++ b/cmake/Findglfw3.cmake
@@ -3,13 +3,15 @@ find_path(glfw3_INCLUDE_DIR
         NAMES glfw3.h
         PATHS
         $ENV{HOME}/.mujoco/mjpro200/include
-        NO_DEFAULT_PATH
+        $ENV{HOME}/.mujoco/mujoco200/include	
+	NO_DEFAULT_PATH
         )
 
 find_library(glfw3_LIBRARIES
         NAMES libglfw.so.3
         PATHS
         $ENV{HOME}/.mujoco/mjpro200/bin
+	$ENV{HOME}/.mujoco/mujoco200/bin
         NO_DEFAULT_PATH
         )
 

--- a/cmake/Findmujoco.cmake
+++ b/cmake/Findmujoco.cmake
@@ -1,14 +1,18 @@
 
 find_path(mujoco_INCLUDE_DIR
         NAMES mujoco.h
-        PATHS $ENV{HOME}/.mujoco/mjpro200/include
-        NO_DEFAULT_PATH
+        PATHS 
+	$ENV{HOME}/.mujoco/mjpro200/include
+        $ENV{HOME}/.mujoco/mujoco200/include
+	NO_DEFAULT_PATH
         )
 
 find_library(mujoco_LIBRARIES
         NAMES libmujoco200.so
-        PATHS $ENV{HOME}/.mujoco/mjpro200/bin 
-        NO_DEFAULT_PATH
+        PATHS
+	$ENV{HOME}/.mujoco/mjpro200/bin 
+        $ENV{HOME}/.mujoco/mujoco200/bin
+	NO_DEFAULT_PATH
         )
 
 #find_library(nvidia_LIBRARIES
@@ -19,7 +23,9 @@ find_library(mujoco_LIBRARIES
 
 find_library(libglew_LIBRARIES
         NAMES libglew.so 
-        PATHS $ENV{HOME}/.mujoco/mjpro200/bin
+        PATHS
+	$ENV{HOME}/.mujoco/mjpro200/bin
+	$ENV{HOME}/.mujoco/mujoco200/bin
         NO_DEFAULT_PATH
         )
 


### PR DESCRIPTION
Hello,
i tried this ROS package and run into an error during the build. CMake was not able to find MuJoCo, because the path is for me `~/.mujoco/mujoco200`. I add additional search paths to the CMake files here.